### PR TITLE
Use javascript-action instead of platform dependent Shell commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,34 +76,54 @@ jobs:
         # Eldev--relint integration, because we use `rx' macro.
         ELDEV_LOCAL=. ./bin/eldev -p -dtTC lint re
 
-    # Method 1: if you have a catch-all directory for executables.  We
-    # don't test bootstrapping, as that is supposed to have been
-    # tested by normal ERT tests.
+    # Method 1: if you have a catch-all directory for executables.
+    # Calling the eldev script will test that it will be bootstraped
+    # correctly when downloaded from the RAW URL.
     - name: Test installation 1
-      run: |
-        mkdir ~/fake-bin
-        cd ~/fake-bin
-        curl -fsSL https://raw.github.com/doublep/eldev/master/bin/eldev > eldev && chmod a+x eldev
-        test -x ~/fake-bin/eldev
+      uses: actions/github-script@v3
+      with:
+        script: |
+          const exec = require('util').promisify(require('child_process').exec);
+          const {downloadScript,expandTilde} = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/util.js`);
+
+          const fakeBin = expandTilde('~/fake-bin');
+          await io.mkdirP(fakeBin);
+          const script = await downloadScript(github, context, "bin/eldev", fakeBin);
+          const eldev_out = await exec(script);
+          console.log(eldev_out.stdout);
 
     # Method 2: general case, with Eldev script installed to
     # `~/.eldev/bin'.  We don't add it to `$PATH' as we never run it.
     - name: Test installation 2
-      run: |
-        ! test -x ~/.eldev/bin/eldev
-        curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-        test -x ~/.eldev/bin/eldev
-        rm -r ~/.eldev/bin
+      uses: actions/github-script@v3
+      with:
+        script: |
+          const fs = require('fs');
+          const exec = require('util').promisify(require('child_process').exec);
+          const {downloadScript,expandTilde} = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/util.js`);
+
+          if (fs.existsSync(expandTilde("~/.eldev/bin/eldev")))
+              throw("~/.eldev/bin/eldev already exists");
+          await io.mkdirP('tmp');
+          const script = await downloadScript(github, context, "webinstall/eldev", 'tmp');
+          await exec(script);
+          const eldev_out = await exec(expandTilde("~/.eldev/bin/eldev"));
+          console.log(eldev_out.stdout);
+          await io.rmRF(expandTilde("~/.eldev/bin"));
 
     # GitHub-specific installation specifically for workflows.
     - name: Test GitHub-specific installation
-      run: |
-        ! test -x ~/.eldev/bin/eldev
-        curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev | sh
-        test -x ~/.eldev/bin/eldev
-
-    - name: ...continued
-      run: |
-        # "" is useful in case `which' returns an empty string.
-        test ""`which eldev` = ~/.eldev/bin/eldev
-        rm -r ~/.eldev/bin
+      uses: actions/github-script@v3
+      with:
+        script: |
+          const fs = require('fs');
+          const exec = require('util').promisify(require('child_process').exec);
+          const {downloadScript,expandTilde} = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/util.js`);
+          if (fs.existsSync(expandTilde("~/.eldev/bin/eldev")))
+              throw("~/.eldev/bin/eldev already exists");
+          await io.mkdirP('tmp');
+          const script = await downloadScript(github, context, "webinstall/github-eldev", 'tmp');
+          await exec(script);
+          const eldev_out = await exec(expandTilde("~/.eldev/bin/eldev"));
+          console.log(eldev_out.stdout);
+          await io.rmRF(expandTilde("~/.eldev/bin"));

--- a/.github/workflows/util.js
+++ b/.github/workflows/util.js
@@ -1,0 +1,37 @@
+const os = require('os');
+const fs = require('fs');
+const {sep, join, basename} = require('path');
+const suffix = (os.type() === 'Windows_NT') ? '.bat' : '';
+
+// Get raw download URL for path in this repo or pull-request repo
+// (depending on context) automatically adds (.bat) extension to path
+// if running on windows to make Github actions steps platform agnostic
+function getRawUrl(context, path) {
+    const {repository, pull_request} = context.payload;
+    const branch = pull_request ? pull_request.head.ref : repository.default_branch;
+    const repo_full_name = pull_request ? pull_request.head.repo.full_name : repository.full_name;
+    return `https://raw.github.com/${repo_full_name}/${branch}/${path}${suffix}`;
+}
+
+// Download script and make it executable (required on Unix)
+async function downloadScript(github, context, file, outdir) {
+    const url = getRawUrl(context, file);
+    const response = await github.request(url);
+    const out = join(outdir, basename(file) + suffix);
+    await fs.promises.writeFile(out, response.data);
+    console.log(`Downloaded ${url} to ${out}`);
+    if (os.type() !== 'Windows_NT') {
+	fs.chmodSync(out, fs.constants.S_IXUSR | fs.constants.S_IRUSR);
+    }
+    return out;
+}
+
+// simple tilde expansion
+function expandTilde(path) {
+    return  path.replace('~', (os.type() === 'Windows_NT') ?  `${process.env.USERPROFILE}${sep}` : `${process.env.HOME}${sep}`);
+}
+
+module.exports = {
+    downloadScript,
+    expandTilde
+};


### PR DESCRIPTION
This change allows to execute github installation  test in a platform-agnostic way  (required to  merge #35  by @ikappak)

Instead of a simple "test -x eldev" test, `eldev` is actually
bootstrapped again to verify that the net-installation was indeed
successful.

The previous `shell` tests also use the hardcoded path
https://raw.github.com/doublep/eldev/master/bin/eldev to download the
eldev scripts. So  CI will not test changes introduced in the PRs.

The utility function `getRawUrl` generates the correct raw download
URL depending on the context (pushing to master or PR) and also adds a
platform dependent suffix (.bat on Windows) to the script name to make
the script download/testing platform-agnostic.
