### PR TITLE
Check if %1 got expanded

### DIFF
--- a/webinstall/eldev.bat
+++ b/webinstall/eldev.bat
@@ -2,11 +2,8 @@
 rem This script downloads Eldev startup script as `%USERPROFILE%/.eldev/bin/eldev'.
 
 rem optionally pass download URL as paramater to allow testing in PRs
-IF [%1] == [] (
-   set URL=https://raw.githubusercontent.com/doublep/eldev/master/bin/eldev.bat
-) else (
-   set URL=%1
-)
+set URL=https://raw.githubusercontent.com/doublep/eldev/master/bin/eldev.bat
+IF [%1] == [] IF NOT %1 == "%1" set URL=%1
 
 set ELDEV_BIN_DIR=%USERPROFILE%\.eldev\bin
 


### PR DESCRIPTION
This prevents an invalid URL from being generated when the
webinstaller is used via a cmd.exe pipe.

Fixes this issue:
```
curl: (6) Could not resolve host: %1
```
In the CI tests we don't pipe the `webinstaller\eldev.bat` into `cmd.exe`. 
That's why this error didn't show up in the CI tests. 