### PR TITLE
Use a more reliable method to test for an empty parameter

### DIFF
--- a/webinstall/eldev.bat
+++ b/webinstall/eldev.bat
@@ -3,7 +3,7 @@ rem This script downloads Eldev startup script as `%USERPROFILE%/.eldev/bin/elde
 
 rem optionally pass download URL as paramater to allow testing in PRs
 set URL=https://raw.githubusercontent.com/doublep/eldev/master/bin/eldev.bat
-IF [%1] == [] IF NOT %1 == "%1" set URL=%1
+IF NOT "%~1" == "" set URL=%1
 
 set ELDEV_BIN_DIR=%USERPROFILE%\.eldev\bin
 


### PR DESCRIPTION
Fixes invalid test condition and also strips outer set of quotes.

Sadly the previous commit 2fe82850cd73d6c7e88a8192d41060f5af865586 was defective.

Reference: https://stackoverflow.com/questions/2541767/what-is-the-proper-way-to-test-if-a-parameter-is-empty-in-a-batch-file

BTW: Thanks for the new MELPA release: 
Seting up ` eldev` using [setup-eldev-emacs](https://github.com/juergenhoetzel/setup-eldev-emacs) works on all major platforms:
https://github.com/juergenhoetzel/github-eldev-test/actions/runs/785613998 
