### PR TITLE
native CRLF support, CI and webinstall fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,19 +50,17 @@ jobs:
       if: startsWith (matrix.os, 'macos')
       run: brew install texinfo mercurial subversion
 
-      # package-install-file' fails with CRLF (Windows) line endings
-    - name: Set git to use LF
-      run: |
-          git config --global core.autocrlf false
-          git config --global core.eol lf
-
     - name: Check out the source code
       uses: actions/checkout@v2
 
     - name: Test the project
       run: |
         ./bin/eldev -p -dtTC test --omit-backtraces --expect 200
-        ./bin/eldev -p -dtTC test --test-type integration --omit-backtraces --expect 5
+      env:
+        ELDEV_LOCAL: "."
+
+    - name: Test integration
+      run: ./bin/eldev -p -dtTC test --test-type integration --omit-backtraces --expect 5
       env:
         ELDEV_LOCAL: "."
 

--- a/.github/workflows/util.js
+++ b/.github/workflows/util.js
@@ -7,8 +7,8 @@ const suffix = (os.type() === 'Windows_NT') ? '.bat' : '';
 // (depending on context) automatically adds (.bat) extension to path
 // if running on windows to make Github actions steps platform agnostic
 function getRawUrl(context, path) {
-    const {repository, pull_request} = context.payload;
-    const branch = pull_request ? pull_request.head.ref : repository.default_branch;
+    const {repository, pull_request, ref} = context.payload;
+    const branch = pull_request ? pull_request.head.ref : ref.replace(/refs\/.+?\//, "");
     const repo_full_name = pull_request ? pull_request.head.repo.full_name : repository.full_name;
     return `https://raw.github.com/${repo_full_name}/${branch}/${path}${suffix}`;
 }

--- a/README.adoc
+++ b/README.adoc
@@ -210,7 +210,7 @@ This will install `eldev` script to `~/.eldev/bin`.
 . Execute:
 +
 --
-    > curl.exe -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev.bat | cmd
+    > curl.exe -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev.bat | cmd /Q
 
 This will install `eldev.bat` script to `%USERPROFILE%\.eldev\bin`.
 --

--- a/bin/bootstrap.el.part
+++ b/bin/bootstrap.el.part
@@ -25,7 +25,7 @@
           (setf package-archives `(("bootstrap-pa" . ,(file-name-as-directory (substring eldev-local (length ":pa:")))))
                 archive-name     "a local package archive")
         (with-temp-buffer
-          (insert-file-contents-literally (expand-file-name "eldev.el" eldev-local))
+          (insert-file-contents (expand-file-name "eldev.el" eldev-local))
           (setf eldev-pkg                    (package-buffer-info)
                 (package-desc-dir eldev-pkg) (expand-file-name eldev-local))
           ;; Currently Eldev has no external dependencies, but let's be generic.

--- a/bin/eldev
+++ b/bin/eldev
@@ -59,7 +59,7 @@ $ELDEV_EMACS --batch --no-site-file --no-site-lisp                              
           (setf package-archives `(("bootstrap-pa" . ,(file-name-as-directory (substring eldev-local (length ":pa:")))))
                 archive-name     "a local package archive")
         (with-temp-buffer
-          (insert-file-contents-literally (expand-file-name "eldev.el" eldev-local))
+          (insert-file-contents (expand-file-name "eldev.el" eldev-local))
           (setf eldev-pkg                    (package-buffer-info)
                 (package-desc-dir eldev-pkg) (expand-file-name eldev-local))
           ;; Currently Eldev has no external dependencies, but let'\''s be generic.

--- a/bin/eldev.bat
+++ b/bin/eldev.bat
@@ -16,7 +16,7 @@ if "%ELDEV_EMACS%" == "" (
    )
 )
 
-set ELDEV_CMD=%0
+set ELDEV_CMD=%~0
 
 set ELDEV_TTY=
 call :CON_ANSI_SUPPORT? %CMDCMDLINE%
@@ -59,7 +59,7 @@ REM the newline variable above MUST be followed by two empty lines.
           (setf package-archives `(("""bootstrap-pa""" . ,(file-name-as-directory (substring eldev-local (length """:pa:"""))))) !NL!^
                 archive-name     """a local package archive""") !NL!^
         (with-temp-buffer !NL!^
-          (insert-file-contents-literally (expand-file-name """eldev.el""" eldev-local)) !NL!^
+          (insert-file-contents (expand-file-name """eldev.el""" eldev-local)) !NL!^
           (setf eldev-pkg                    (package-buffer-info) !NL!^
                 (package-desc-dir eldev-pkg) (expand-file-name eldev-local)) !NL!^
           ;; Currently Eldev has no external dependencies, but let's be generic. !NL!^

--- a/bin/eldev.bat.in
+++ b/bin/eldev.bat.in
@@ -16,7 +16,7 @@ if "%ELDEV_EMACS%" == "" (
    )
 )
 
-set ELDEV_CMD=%0
+set ELDEV_CMD=%~0
 
 set ELDEV_TTY=
 call :CON_ANSI_SUPPORT? %CMDCMDLINE%

--- a/test/package.el
+++ b/test/package.el
@@ -27,30 +27,30 @@
          (should (= exit-code 0))
          (setf descriptor (read stdout)))
        (ignore-errors (delete-directory test-emacs-dir t))
-       (with-eldev-normalized-package-file package-file
-         (eldev--test-call-process "Emacs" eldev-emacs-executable
-                                   ("--batch" "--no-site-file" "--no-site-lisp" "--execute"
-                                    `(progn
-                                       (require 'package)
-                                       (let ((package-user-dir ,test-emacs-dir)
-                                             ;; Just use all we have, no need to
-                                             ;; tailor for each test specifically.
-                                             (package-archives '(("archive-a" . ,(expand-file-name "package-archive-a/" (eldev--test-dir)))
-                                                                 ("archive-b" . ,(expand-file-name "package-archive-b/" (eldev--test-dir))))))
-                                         (package-initialize t)
-                                         (package-refresh-contents)
-                                         (package-install-file ,package-file)
-                                         (package-activate ',(package-desc-name descriptor))
-                                         (prin1 (cadr (assq ',(package-desc-name descriptor) package-alist)))
-                                         ,',child-emacs-form)))
-           (should (= exit-code 0))
-           ;; Cannot compare just like that.
-           (let ((installed-desciptor (read stdout)))
-             (should (equal (package-desc-name    descriptor) (package-desc-name    installed-desciptor)))
-             (should (equal (package-desc-version descriptor) (package-desc-version installed-desciptor)))
-             (should (equal (package-desc-reqs    descriptor) (package-desc-reqs    installed-desciptor)))
-             (should (equal (package-desc-extras  descriptor) (package-desc-extras  installed-desciptor))))
-           ,@body)))))
+       (eldev--test-call-process "Emacs" eldev-emacs-executable
+                                 ("--batch" "--no-site-file" "--no-site-lisp" "--execute"
+                                  `(progn
+                                     (require 'package)
+                                     (let ((package-user-dir ,test-emacs-dir)
+                                           ;; Just use all we have, no need to
+                                           ;; tailor for each test specifically.
+                                           (package-archives '(("archive-a" . ,(expand-file-name "package-archive-a/" (eldev--test-dir)))
+                                                               ("archive-b" . ,(expand-file-name "package-archive-b/" (eldev--test-dir))))))
+                                       (package-initialize t)
+                                       (package-refresh-contents)
+                                       (load (expand-file-name "./eldev-util.el"))
+                                       (eldev--package-install-file ,package-file)
+                                       (package-activate ',(package-desc-name descriptor))
+                                       (prin1 (cadr (assq ',(package-desc-name descriptor) package-alist)))
+                                       ,',child-emacs-form)))
+         (should (= exit-code 0))
+         ;; Cannot compare just like that.
+         (let ((installed-desciptor (read stdout)))
+           (should (equal (package-desc-name    descriptor) (package-desc-name    installed-desciptor)))
+           (should (equal (package-desc-version descriptor) (package-desc-version installed-desciptor)))
+           (should (equal (package-desc-reqs    descriptor) (package-desc-reqs    installed-desciptor)))
+           (should (equal (package-desc-extras  descriptor) (package-desc-extras  installed-desciptor))))
+         ,@body))))
 
 
 (ert-deftest eldev-package-1 ()

--- a/test/package.el
+++ b/test/package.el
@@ -27,29 +27,30 @@
          (should (= exit-code 0))
          (setf descriptor (read stdout)))
        (ignore-errors (delete-directory test-emacs-dir t))
-       (eldev--test-call-process "Emacs" eldev-emacs-executable
-                                 ("--batch" "--no-site-file" "--no-site-lisp" "--execute"
-                                  `(progn
-                                     (require 'package)
-                                     (let ((package-user-dir ,test-emacs-dir)
-                                           ;; Just use all we have, no need to
-                                           ;; tailor for each test specifically.
-                                           (package-archives '(("archive-a" . ,(expand-file-name "package-archive-a/" (eldev--test-dir)))
-                                                               ("archive-b" . ,(expand-file-name "package-archive-b/" (eldev--test-dir))))))
-                                       (package-initialize t)
-                                       (package-refresh-contents)
-                                       (package-install-file ,package-file)
-                                       (package-activate ',(package-desc-name descriptor))
-                                       (prin1 (cadr (assq ',(package-desc-name descriptor) package-alist)))
-                                       ,',child-emacs-form)))
-         (should (= exit-code 0))
-         ;; Cannot compare just like that.
-         (let ((installed-desciptor (read stdout)))
-           (should (equal (package-desc-name    descriptor) (package-desc-name    installed-desciptor)))
-           (should (equal (package-desc-version descriptor) (package-desc-version installed-desciptor)))
-           (should (equal (package-desc-reqs    descriptor) (package-desc-reqs    installed-desciptor)))
-           (should (equal (package-desc-extras  descriptor) (package-desc-extras  installed-desciptor))))
-         ,@body))))
+       (with-eldev-normalized-package-file package-file
+         (eldev--test-call-process "Emacs" eldev-emacs-executable
+                                   ("--batch" "--no-site-file" "--no-site-lisp" "--execute"
+                                    `(progn
+                                       (require 'package)
+                                       (let ((package-user-dir ,test-emacs-dir)
+                                             ;; Just use all we have, no need to
+                                             ;; tailor for each test specifically.
+                                             (package-archives '(("archive-a" . ,(expand-file-name "package-archive-a/" (eldev--test-dir)))
+                                                                 ("archive-b" . ,(expand-file-name "package-archive-b/" (eldev--test-dir))))))
+                                         (package-initialize t)
+                                         (package-refresh-contents)
+                                         (package-install-file ,package-file)
+                                         (package-activate ',(package-desc-name descriptor))
+                                         (prin1 (cadr (assq ',(package-desc-name descriptor) package-alist)))
+                                         ,',child-emacs-form)))
+           (should (= exit-code 0))
+           ;; Cannot compare just like that.
+           (let ((installed-desciptor (read stdout)))
+             (should (equal (package-desc-name    descriptor) (package-desc-name    installed-desciptor)))
+             (should (equal (package-desc-version descriptor) (package-desc-version installed-desciptor)))
+             (should (equal (package-desc-reqs    descriptor) (package-desc-reqs    installed-desciptor)))
+             (should (equal (package-desc-extras  descriptor) (package-desc-extras  installed-desciptor))))
+           ,@body)))))
 
 
 (ert-deftest eldev-package-1 ()

--- a/webinstall/circle-eldev.ps1
+++ b/webinstall/circle-eldev.ps1
@@ -1,0 +1,18 @@
+# This script downloads Eldev startup script as `~\.eldev\bin\eldev.bat'
+# for CircleCI, and permanently adds that directory at the front of PATH
+# in PS's startup profile, so as to be available in every session.
+#
+# In your `.circleci/config.yml' add this:
+#
+# - (iwr https://raw.github.com/doublep/eldev/master/webinstall/circle-eldev.ps1).Content | powershell -command -
+
+$ErrorActionPreference = "Stop"
+
+
+$env:ELDEV_BIN_DIR="$HOME\.eldev\bin"
+
+if (!(Test-Path $env:ELDEV_BIN_DIR)) {new-item "$env:ELDEV_BIN_DIR" -ItemType directory}
+iwr -Uri https://raw.githubusercontent.com/doublep/eldev/master/bin/eldev.bat `
+  -outfile $env:ELDEV_BIN_DIR/eldev.bat
+
+add-content $PROFILE $("`$env:PATH=""$env:ELDEV_BIN_DIR;`$env:PATH""")

--- a/webinstall/eldev.bat
+++ b/webinstall/eldev.bat
@@ -3,16 +3,16 @@ rem This script downloads Eldev startup script as `%USERPROFILE%/.eldev/bin/elde
 rem
 rem To bootstrap, run as follows from a command prompt:
 rem
-rem curl.exe -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev.bat | cmd
+rem curl.exe -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev.bat | cmd /Q
 
 rem The usual way to check for the presence of an argument is to test
-rem if their argument reference %[1-9] has a value. Though when
-rem piping, these references do not exist and instead is better to use
+rem if their argument reference %[1-9] has a value. Though when piping
+rem to cmd, these references do not exist and instead is better to use
 rem a counter.
 set ARGS=0
 for %%x in (%*) do set /A ARGS+=1
 
-rem optionally pass download URL as paramater to allow testing in PRs
+rem optionally pass download URL as parameter to allow testing in PRs
 set URL=https://raw.githubusercontent.com/doublep/eldev/master/bin/eldev.bat
 if %ARGS%==1 set URL=%1
 
@@ -20,10 +20,10 @@ set ELDEV_BIN_DIR=%USERPROFILE%\.eldev\bin
 
 mkdir %ELDEV_BIN_DIR%
 
-curl.exe  -fsSL %URL% -o %ELDEV_BIN_DIR%\eldev.bat && (
+curl.exe  -fsSL %URL% -o %ELDEV_BIN_DIR%\eldev.bat || exit /b
+
 echo Eldev startup script has been installed.
 echo Don't forget to add `%ELDEV_BIN_DIR% to PATH environment variable:
 echo.
 echo     set PATH=%ELDEV_BIN_DIR%;%%PATH%%
-)
 

--- a/webinstall/eldev.bat
+++ b/webinstall/eldev.bat
@@ -1,18 +1,29 @@
 @echo off
 rem This script downloads Eldev startup script as `%USERPROFILE%/.eldev/bin/eldev'.
+rem
+rem To bootstrap, run as follows from a command prompt:
+rem
+rem curl.exe -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev.bat | cmd
+
+rem The usual way to check for the presence of an argument is to test
+rem if their argument reference %[1-9] has a value. Though when
+rem piping, these references do not exist and instead is better to use
+rem a counter.
+set ARGS=0
+for %%x in (%*) do set /A ARGS+=1
 
 rem optionally pass download URL as paramater to allow testing in PRs
 set URL=https://raw.githubusercontent.com/doublep/eldev/master/bin/eldev.bat
-IF NOT "%~1" == "" set URL=%1
+if %ARGS%==1 set URL=%1
 
 set ELDEV_BIN_DIR=%USERPROFILE%\.eldev\bin
 
 mkdir %ELDEV_BIN_DIR%
 
-curl.exe  -fsSL %URL% -o %ELDEV_BIN_DIR%\eldev.bat
-
+curl.exe  -fsSL %URL% -o %ELDEV_BIN_DIR%\eldev.bat && (
 echo Eldev startup script has been installed.
 echo Don't forget to add `%ELDEV_BIN_DIR% to PATH environment variable:
 echo.
 echo     set PATH=%ELDEV_BIN_DIR%;%%PATH%%
+)
 


### PR DESCRIPTION
Please consider below fixes from observations made while trying to enable MS-Windows test support in CIDER.

- Two workarounds for [Emacs bug#48137](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=48137) which results to `'package` fns failing when passed a package file with DOS line endings. 
  1. `bin/boostra.el.part` has been updated not load `eldev.el` "-literally" any more, thus enforcing the correct line endings in the buffer (CRLFs are treated as a single `?\n`). This prevented the eldev project from bootstrapping after it was cloned from git with config `core.autocrlf=true` (the default setting for github and circleci workflows). The previous workaround forcing LF line endings in `.github/workflows/test.yml` has thus been removed.
  2. A new wrapper function `eldev-util.el:with-eldev-normalized-package-file` macro is introduced to convert DOS line endings to UNIX  of a package file in a new temporary file, if required, before passing  it to`package-install-file` for evaluation. It is utilised in `eldev-util.el:eldev-install-package-file` and `test/package.el:eldev--test-packaging` as necessary.

 - The project tests have been moved into their own `run` blocks in `.github/workflows/test.yml` so that failures are caught independently by the workflow (previously if main tests failed but integration tests succeeded would still show the `run` block as green).

- The `.github/workflows/util.js` has been updated to reference the branch name rather than default to `master` when used in the workflow, thus enabling installation tests to reference the active branch.

- `bin\eldev.bat.in` has been updated to strip out double quotes (`%~0`) from `ELDEV_CMD`. It turns out that when invoked from PowerShell the path to program name is wrapped in double quotes. This resulted in eldev path errors when trying to determine the location of the eldev script.

- Introduced `webinstall/circle-eldev.ps1` to be used with circleci windows workflows, modelled as close as possible after `webinstall/circle-eldev`. The choice of using a PowerShell vs. bat script here is because circleci's default windows shell is PowerShell.

- Fixed an issue with `webinstall/eldev.bat` that it fails when piped to `cmd` as per the official instructions in `README.adoc`. This is because the command line arguments `%[1-9]` do not exist when piping to `cmd`.  (Hi @juergenhoetzel, has this ever worked for you or perhaps there is something different in my setup? I suspect it is the check for the additional argument that has broken it since).

Thanks