### PR TITLE
Inhibit end-of-line conversion in tar-mode buffer

### DIFF
--- a/test/upgrade-self.el
+++ b/test/upgrade-self.el
@@ -81,11 +81,9 @@
 ;; incorrectly, against old (or missing) definitions.
 (eldev-ert-defargtest eldev-upgrade-self-new-macros-1 (mode)
                       ('normal 'external)
-  (when (eq system-type 'windows-nt)
-    ;; The issue is in editing `.tar' archive with Emacs.
-    (ert-skip "this test is known to fail on Windows because of an issue unrelated to Eldev"))
   (eldev--test-create-eldev-archive "eldev-archive-1")
   (let ((inhibit-message t)
+        (inhibit-eol-conversion t)
         (archive-2-dir   (eldev--test-create-eldev-archive "eldev-archive-2" "999.9"))
         tar-buffers)
     ;; Inject a macro for testing purposes.  We can edit `.tar' archives with Elisp


### PR DESCRIPTION
This is a workaround to prevent corrupt tar files on windows.

This reverts commit 9e59d6 (Disable the tests added in commit 1f093ac on Windows, because of an issue unrelated to Eldev)

Refs #43