### PR TITLE
Fix argument parsing issue for Windows github web-installer

### DIFF
--- a/webinstall/github-eldev.bat
+++ b/webinstall/github-eldev.bat
@@ -1,24 +1,27 @@
-rem This script downloads Eldev startup script as `USERPROFILE/.eldev/bin/eldev'
-rem for use in a GitHub workflow.
+@echo off
+rem This script downloads Eldev startup script as `%USERPROFILE%/.eldev/bin/eldev'.
 rem
 rem curl.exe is included in Windows 10 since April-2018-Update (1803)
 rem In your `.github/workflows/*.yml' add this:
 rem
-rem   run: curl.exe  -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev.bat | cmd
-rem
+rem curl.exe -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev.bat | cmd /Q
 
-rem optionally pass download URL as paramater to allow testing in eldev PRs
-IF [%1] == [] (
-   set URL=https://raw.githubusercontent.com/doublep/eldev/master/bin/eldev.bat
-) else (
-   set URL=%1
-)
+rem The usual way to check for the presence of an argument is to test
+rem if their argument reference %[1-9] has a value. Though when piping
+rem to cmd, these references do not exist and instead is better to use
+rem a counter.
+set ARGS=0
+for %%x in (%*) do set /A ARGS+=1
+
+rem optionally pass download URL as parameter to allow testing in PRs
+set URL=https://raw.githubusercontent.com/doublep/eldev/master/bin/eldev.bat
+if %ARGS%==1 set URL=%1
 
 set ELDEV_BIN_DIR=%USERPROFILE%\.eldev\bin
 
 mkdir %ELDEV_BIN_DIR%
 
-curl.exe  -fsSL %URL% -o %ELDEV_BIN_DIR%\eldev.bat
+curl.exe  -fsSL %URL% -o %ELDEV_BIN_DIR%\eldev.bat || exit /b
 
 echo %ELDEV_BIN_DIR% >> %GITHUB_PATH%
 


### PR DESCRIPTION
Command line arguments %[1-9] do not exist when piping to CMD.

This is a follow up for https://github.com/doublep/eldev/pull/41 where we missed to fix the issue also for the github webinstaller.

