### PR TITLE
Fix windows script update

### DIFF
--- a/eldev.el
+++ b/eldev.el
@@ -2237,7 +2237,7 @@ Since 0.2."
     (dolist (script scripts)
       (catch 'continue
         (let* ((installed      (eldev-shell-command))
-               (installed-name (file-name-base installed)))
+               (installed-name (file-name-nondirectory installed)))
           (unless (string= installed-name script)
             (if (member installed-name scripts)
                 (setf installed (expand-file-name script (file-name-directory installed)))

--- a/test/upgrade-self.el
+++ b/test/upgrade-self.el
@@ -115,7 +115,7 @@
     (eldev--test-create-eldev-archive "eldev-archive-2" "999.9"
                                       `("bin/eldev"     ,(rx "#! /bin/sh\n") "# TEST-COMMENT\n")
                                       `("bin/eldev.ps1" nil                  "# TEST-COMMENT\n")
-                                      `("bin/eldev.bat" ,(rx "@echo off")    "REM TEST-COMMENT\n"))
+                                      `("bin/eldev.bat" ,(rx line-start "exit /b" line-end)    "\nREM TEST-COMMENT\n"))
     (eldev--test-with-external-dir "trivial-project" ()
       :enabled (eq mode 'external)
       (let ((eldev--test-eldev-local (concat ":pa:" (eldev--test-tmp-subdir "eldev-archive-1")))

--- a/test/upgrade-self.el
+++ b/test/upgrade-self.el
@@ -84,8 +84,8 @@
   ;; Inject a macro for testing purposes.  If the macro and its usage were in the same
   ;; file, bug would not be triggered.
   (eldev--test-create-eldev-archive "eldev-archive-2" "999.9"
-                                    `("eldev.el"      ,(rx "\n(provide 'eldev)\n")      "(defun eldev--test-function () (eldev--test-new-macro))\n")
-                                    `("eldev-util.el" ,(rx "\n(provide 'eldev-util)\n") "(defmacro eldev--test-new-macro () 1)\n"))
+                                    `("eldev.el"      ,(rx line-start "(provide 'eldev)")      "(defun eldev--test-function () (eldev--test-new-macro))\n")
+                                    `("eldev-util.el" ,(rx line-start "(provide 'eldev-util)") "(defmacro eldev--test-new-macro () 1)\n"))
   (eldev--test-with-external-dir "trivial-project" ()
     :enabled (eq mode 'external)
     (let ((eldev--test-eldev-local (concat ":pa:" (eldev--test-tmp-subdir "eldev-archive-1")))
@@ -113,9 +113,9 @@
     (eldev--test-create-eldev-archive "eldev-archive-1")
     ;; Modify our scripts for testing purposes only.
     (eldev--test-create-eldev-archive "eldev-archive-2" "999.9"
-                                      `("bin/eldev"     ,(rx "#! /bin/sh\n") "# TEST-COMMENT\n")
+                                      `("bin/eldev"     ,(rx line-start "#! /bin/sh") "\n# TEST-COMMENT\n")
                                       `("bin/eldev.ps1" nil                  "# TEST-COMMENT\n")
-                                      `("bin/eldev.bat" ,(rx line-start "exit /b" line-end)    "\nREM TEST-COMMENT\n"))
+                                      `("bin/eldev.bat" ,(rx line-start "exit /b")    "\nREM TEST-COMMENT\n"))
     (eldev--test-with-external-dir "trivial-project" ()
       :enabled (eq mode 'external)
       (let ((eldev--test-eldev-local (concat ":pa:" (eldev--test-tmp-subdir "eldev-archive-1")))


### PR DESCRIPTION
This is really an obscure issue. Fixes:

```
             Cannot locate installed script `eldev.ps1', skipping
             Cannot locate installed script `eldev.bat', skipping
```

and 

```
[00:14.519]  Stdout contents:
             Upgraded or installed 1 package
             Upgraded script `c:/Users/PIDSLE~1/AppData/Local/Temp/eldev-xoazUY-test-bin/bin/eldev.ps1'
             Upgraded script `c:/Users/PIDSLE~1/AppData/Local/Temp/eldev-xoazUY-test-bin/bin/eldev.bat'

[00:14.530]  Stderr contents:
             [1/1] Upgrading package `eldev' (0.9.2snapshot -> 999.9) from `bootstrap-pa'...
             Der Befehl "--" ist entweder falsch geschrieben oder
             konnte nicht gefunden werden.

```
Appending the "rem" comment instead of prepending fixes the issue.

Running a `.bat` script  while it is updating itself seems to lead to obscure errors as listed above.