### PR TITLE
Include `>' in the list of chars to escape when quoting batch text

### DIFF
--- a/bin/eldev.bat
+++ b/bin/eldev.bat
@@ -46,7 +46,7 @@ REM the newline variable above MUST be followed by two empty lines.
   (setf package-user-dir !NL!^
         (expand-file-name """bootstrap""" !NL!^
                           (expand-file-name eldev--emacs-version !NL!^
-                                            (if (> (length eldev--dir) 0) !NL!^
+                                            (if (^> (length eldev--dir) 0) !NL!^
                                                 eldev--dir !NL!^
                                               (if (file-directory-p """~/.eldev""") !NL!^
                                                   """~/.eldev""" !NL!^

--- a/eldev-util.el
+++ b/eldev-util.el
@@ -285,7 +285,7 @@ parameter, but it's not needed in noninteractive use."
 
        ;; escape special characters with ^
        (goto-char (point-min))
-       (while (re-search-forward "&\\|<" nil t)
+       (while (re-search-forward "&\\|<\\|>" nil t)
          (replace-match "^\\&"))
 
        ;; escape % with %%


### PR DESCRIPTION
Fixes MS-Windows CI test bootstrap failure due to change in #62.