### PR TITLE
Revert CI win 27.2 missing certificate MSYS2 workaround

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,21 +39,9 @@ jobs:
 
     - name: Set up Emacs on Windows
       if: startsWith (matrix.os, 'windows')
-      # Use MSYS2 as a temporary workaround for issue #55 with Emacs
-      # official MS-Windows prebuilt 27.2 binaries.
-      #
-      # uses: purcell/setup-emacs@master
-      # with:
-      #   version: ${{matrix.emacs_version}}
-      uses: msys2/setup-msys2@v2
+      uses: jcs090218/setup-emacs-windows@master
       with:
-        release: false
-        path-type: inherit
-        install: mingw64/mingw-w64-x86_64-emacs
-    - name: Add MSYS2 packages directory to PATH
-      if: startsWith (matrix.os, 'windows')
-      run: |
-        echo "c:/msys64/mingw64/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        version: ${{matrix.emacs_version}}
 
     - name: Set up additional packages (Ubuntu)
       if: startsWith (matrix.os, 'ubuntu')


### PR DESCRIPTION
Could you please review change to revert the 27.1 CI workaround now that 28.1 is out please?

All tests pass.

Thanks