### PR TITLE
Fix/GitHub eldev install win

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,20 +122,29 @@ jobs:
           await io.rmRF(expandTilde("~/.local/bin"));
 
     # GitHub-specific installation specifically for workflows.
-    - name: Test GitHub-specific installation
-      uses: actions/github-script@v3
-      with:
-        script: |
-          const fs = require('fs');
-          const exec = require('util').promisify(require('child_process').exec);
-          const {getRawUrl,downloadScript,expandTilde} = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/util.js`);
-          if (fs.existsSync(expandTilde("~/.local/bin/eldev")))
-              throw("~/.local/bin/eldev already exists");
-          await io.mkdirP('tmp');
-          const script = await downloadScript(github, context, "webinstall/github-eldev", 'tmp');
-          const eldev_bin_url = getRawUrl(context,"bin/eldev");
-          await exec(`${script} ${eldev_bin_url}`);
-          const eldev_out = await exec(expandTilde("~/.local/bin/eldev"));
-          console.log(eldev_out.stdout);
-          await io.rmRF(expandTilde("~/.local/bin"));
+    - name: Test GitHub-specific installation (1/2)
+      if: "!startsWith (matrix.os, 'windows')"
+      run: |
+        if command -v eldev &> /dev/null
+        then
+         echo eldev is already installed.
+         exit 1
+        else
+          curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev | sh
+        fi
 
+    - name: Test GitHub-specific installation on MS-Windows (1/2)
+      if: startsWith (matrix.os, 'windows')
+      run: |
+        if (Get-Command "eldev" -ErrorAction SilentlyContinue)
+        {
+          throw 'eldev is already installed.'
+        }
+        else
+        {
+          curl.exe -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev.bat | cmd /Q
+        }
+
+    - name: Test GitHub-specific installation (2/2)
+      run: |
+        eldev help && rm ~/.local/bin/eldev*

--- a/webinstall/github-eldev.bat
+++ b/webinstall/github-eldev.bat
@@ -23,5 +23,5 @@ mkdir %ELDEV_BIN_DIR%
 
 curl.exe  -fsSL %URL% -o %ELDEV_BIN_DIR%\eldev.bat || exit /b
 
-echo %ELDEV_BIN_DIR% >> %GITHUB_PATH%
+echo %ELDEV_BIN_DIR%>> %GITHUB_PATH%
 


### PR DESCRIPTION
Hi,

can you please consider patchfor github-eldev.bat installations script that fixes #70.

It appears that the MS-Windows github installation script does not set the eldev installation path correctly, it adds additional space at the end when running the `echo`, and thus the end path has an additional space at the end (!), which is invisible to the naked eye .... Not sure how this ever worked.

I've also included a new CI workflow that tests the github installation scripts across the supported architectures. This is a separate file, so that it does not interfere with the actual eldev tests.

Thanks,