### PR TITLE
Fix Emacs 26 bootstrap quoting issue with trailing newline

### DIFF
--- a/bin/eldev.bat
+++ b/bin/eldev.bat
@@ -99,10 +99,7 @@ REM the newline variable above MUST be followed by two empty lines.
         (package-activate-1 eldev-pkg) !NL!^
         (advice-remove #'load autoloads-disabler)))) !NL!^
   (require 'eldev) !NL!^
-  (eldev-start-up)) !NL!^
-"  ^
-                --execute "(kill-emacs (eldev-cli (append (cdr (member """--""" command-line-args)) nil)))" ^
-                -- !ARGS!
+  (eldev-start-up))" --execute "(kill-emacs (eldev-cli (append (cdr (member """--""" command-line-args)) nil)))" -- !ARGS!
 REM forward emacs exit status
 exit /b %errorlevel%
 

--- a/bin/eldev.bat.in
+++ b/bin/eldev.bat.in
@@ -27,9 +27,7 @@ if "%CON_ANSI_SUPPORT?%" == "t" (
 @[(eldev-bat-quote :init)]@
 
 "%ELDEV_EMACS%" --batch --no-site-file --no-site-lisp ^
-                --execute  @[(eldev-bat-quote :string (eldev-file-contents "bin/bootstrap.el.part" 0 1))]@  ^
-                --execute "(kill-emacs (eldev-cli (append (cdr (member """--""" command-line-args)) nil)))" ^
-                -- @[(eldev-bat-quote :args)]@
+                --execute  @[(progn (require 'subr-x) (eldev-bat-quote :string (string-trim (eldev-file-contents "bin/bootstrap.el.part" 0 1))))]@ --execute "(kill-emacs (eldev-cli (append (cdr (member """--""" command-line-args)) nil)))" -- @[(eldev-bat-quote :args)]@
 REM forward emacs exit status
 exit /b %errorlevel%
 

--- a/eldev-util.el
+++ b/eldev-util.el
@@ -281,7 +281,7 @@ parameter, but it's not needed in noninteractive use."
 
        ;; close the quoted text with a double quote.
        (goto-char (point-max))
-       (insert "\n\"")
+       (insert "\"")
 
        ;; escape special characters with ^
        (goto-char (point-min))


### PR DESCRIPTION
Fixes Emacs 26 issue with the command line `--execute "..."` option that does not allow newline characters at the end of the quoted command (#72).

Currently Eldev always appends a newline when `eldev-bat-quote`ing the bootstrap code (where it shouldn't add anything more to it).  The patch remove this extraneous newline character. It also ensures that it removes any newlines from the bootstrap code in `eldev.bat.in` by trimming the bootstrap contents.

Finally, there is a unexplained bizarreness with the .bat file reader that it will not allow the second `--execute` to be on its own line if `"` is not the first line character in our case, and thus all command line options after the first `--execute` have been merged into one line. 

I have not included a test since this will require running Emacs 26 Windows in GitHub CI, which would be too much to ask for. I would say older Emacs versions on Windows are on a best effort support, and if it silently breaks, so be it until someone complains.

Thanks