### PR TITLE
Escape -- with double quotes (powershell compatibility)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
         # Run `doctor' on the project itself.  Git hooks are not going
         # to be installed in this checkout.  Also, don't insist on
         # recent stable releases here.
-        ./bin/eldev -p -dtTC doctor -- -githooks -recent-stable-releases
+        ./bin/eldev -p -dtTC doctor "--" -githooks -recent-stable-releases
       env:
         ELDEV_LOCAL: "."
 


### PR DESCRIPTION
It appears double dashes are special in PowerShell and need quoting, see https://stackoverflow.com/questions/15780174/powershell-command-line-parameters-and.

Patch fixes recent MS-windows CI run of `eldev doctor` break with https://github.com/doublep/eldev/commit/ab5c7a9612a5bc541cdc1414aa94707c9490d9cc